### PR TITLE
Removed functionality that returns basic_info because prices.info has the same information and more.

### DIFF
--- a/backend/src/tools/get_stock_quote.py
+++ b/backend/src/tools/get_stock_quote.py
@@ -12,9 +12,7 @@ def get_stock_quote(ticker: str) -> dict:
     Used for getting the price and information about the stock for today.
     """
     prices = yf.Ticker(ticker)
-    basic_info = dict(prices.fast_info)
 
     return {
-        "basic_info": basic_info,
         "information": prices.info   
     }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       context: frontend
       dockerfile: Dockerfile
     ports:
-      - 8501:8501
+      - ${CHAT_PORT}:${CHAT_PORT}
     env_file:
       - .env
     environment:


### PR DESCRIPTION
Trying to reduce the token count in order to process more data without having to remove information from chat history.  