### PR TITLE
The thread id from the streamlit app was blank.

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/frontend/src/server.py
+++ b/frontend/src/server.py
@@ -32,7 +32,7 @@ if "messages" not in st.session_state:
             """
         }
     ]
-    st.session_state["thread_id"] = uuid4()
+    st.session_state["thread_id"] = str(uuid4())
 
 for message in st.session_state["messages"]:
     st.chat_message(message["role"]).write(message["content"])


### PR DESCRIPTION
The thread id that was being passed in from the streamlit application was blank and was needed to be converted to a string.   Getting ready to implement unit tests.